### PR TITLE
Remove `mypy` from main dependencies list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ disallow_untyped_defs = "True"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 langchain-core = "^0.3.15"
-mypy = "^1.15.0"
 langchain = "^0.3.20"
 aiohttp = "^3.11.14"
 requests = "^2.32.3"


### PR DESCRIPTION
See issue #24
I didn't include poetry.lock, but if needed I can