### PR TITLE
Add include_usage plumbing to Tavily LangChain tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ if not os.environ.get("TAVILY_API_KEY"):
     os.environ["TAVILY_API_KEY"] = getpass.getpass("Tavily API key:\n")
 ```
 
+> **Usage reporting note:** Every Tavily endpoint now accepts an optional `include_usage` boolean flag. Set it to `True` when you need credit usage information in the response. Credit usage defaults to `False` and may be reported as `0` until Tavily's internal thresholds are reached for a given endpoint.
+
 ## Tavily Search
 
 Here we show how to instantiate an instance of the Tavily search tool. The tool accepts various parameters to customize the search. After instantiation we invoke the tool with a simple query. This tool allows you to complete search queries using Tavily's Search API endpoint.
@@ -51,6 +53,7 @@ The tool accepts various parameters during instantiation:
 - `include_domains` (optional, List[str]): List of domains to specifically include. Default is None.
 - `exclude_domains` (optional, List[str]): List of domains to specifically exclude. Default is None.
 - `country` (optional, str): Boost search results from a specific country. This will prioritize content from the selected country in the search results. Available only if topic is general.
+- `include_usage` (optional, bool): Whether to include credit usage information in the response. Defaults to False and may initially report as 0 until thresholds are met.
 
 For a comprehensive overview of the available parameters, refer to the [Tavily Search API documentation](https://docs.tavily.com/documentation/api-reference/endpoint/search)
 
@@ -78,7 +81,7 @@ tool = TavilySearch(
 The Tavily search tool accepts the following arguments during invocation:
 
 - `query` (required): A natural language search query
-- The following arguments can also be set during invocation : `include_images`, `include_favicon`, `search_depth` , `time_range`, `include_domains`, `exclude_domains`
+- The following arguments can also be set during invocation : `include_images`, `include_favicon`, `include_usage`, `search_depth`, `time_range`, `include_domains`, `exclude_domains`
 - For reliability and performance reasons, certain parameters that affect response size cannot be modified during invocation: `include_answer` and `include_raw_content`. These limitations prevent unexpected context window issues and ensure consistent results.
 
 NOTE: If you set an argument during instantiation this value will persist and overwrite the value passed during invocation.
@@ -176,6 +179,7 @@ The tool accepts various parameters during instantiation:
 - `include_images` (optional, bool): Whether to include images in the extraction. Default is False.
 - `include_favicon` (optional, bool): Whether to include the favicon URL for each result. Default is False.
 - `format` (optional, str): The format of the extracted web page content. "markdown" returns content in markdown format. "text" returns plain text and may increase latency.
+- `include_usage` (optional, bool): Whether to include credit usage information in the response. Defaults to False and may show 0 until usage thresholds are met.
 
 For a comprehensive overview of the available parameters, refer to the [Tavily Extract API documentation](https://docs.tavily.com/documentation/api-reference/endpoint/extract)
 
@@ -195,7 +199,7 @@ tool = TavilyExtract(
 The Tavily extract tool accepts the following arguments during invocation:
 
 - `urls` (required): A list of URLs to extract content from.
-- The parameters `extract_depth`, `include_images`, and `include_favicon` can also be set during invocation
+- The parameters `extract_depth`, `include_images`, `include_favicon`, and `include_usage` can also be set during invocation
 
 NOTE: If you set an argument during instantiation this value will persist and overwrite the value passed during invocation.
 
@@ -242,6 +246,7 @@ The tool accepts various parameters during instantiation:
 - `extract_depth` (optional, str): Depth of content extraction, either "basic" or "advanced". Default is "basic".
 - `include_favicon` (optional, bool): Whether to include the favicon URL for each result. Default is False.
 - `format` (optional, str): The format of the extracted web page content. "markdown" returns content in markdown format. "text" returns plain text and may increase latency.
+- `include_usage` (optional, bool): Whether to include credit usage information in the response. Defaults to False and may report as 0 until Tavily's reporting thresholds are reached.
 
 For a comprehensive overview of the available parameters, refer to the [Tavily Crawl API documentation](https://docs.tavily.com/documentation/api-reference/endpoint/crawl)
 
@@ -270,7 +275,7 @@ tool = TavilyCrawl(
 
 The Tavily crawl tool accepts the following arguments during invocation:
 - `url` (required): The root URL to begin the crawl.
-- All other parameters can also be set during invocation: `max_depth`, `max_breadth`, `limit`, `instructions`, `select_paths`, `select_domains`, `exclude_paths`, `exclude_domains`,`allow_external`, `include_images`, `categories`, `extract_depth`, and `include_favicon`
+- All other parameters can also be set during invocation: `max_depth`, `max_breadth`, `limit`, `instructions`, `select_paths`, `select_domains`, `exclude_paths`, `exclude_domains`,`allow_external`, `include_images`, `categories`, `extract_depth`, `include_favicon`, and `include_usage`
 
 NOTE: If you set an argument during instantiation this value will persist and overwrite the value passed during invocation.
 
@@ -319,6 +324,7 @@ The tool accepts various parameters during instantiation:
 - `exclude_domains` (optional, List[str]): Regex patterns to exclude specific domains or subdomains from mapping 
 - `allow_external` (optional, bool): Allow following external domain links. Default is False.
 - `categories` (optional, str): Filter URLs by predefined categories ("Careers", "Blogs", "Documentation", "About", "Pricing", "Community", "Developers", "Contact", "Media").
+- `include_usage` (optional, bool): Whether to include credit usage information in the response. Defaults to False and may report as 0 until Tavily's reporting thresholds for the map endpoint are met.
 
 For a comprehensive overview of the available parameters, refer to the [Tavily Map API documentation](https://docs.tavily.com/documentation/api-reference/endpoint/map)
 
@@ -343,7 +349,7 @@ tool = TavilyMap(
 
 The Tavily map tool accepts the following arguments during invocation:
 - `url` (required): The root URL to begin the mapping.
-- All other parameters can also be set during invocation: `max_depth`, `max_breadth`, `limit`, `instructions`, `select_paths`, `select_domains`, `exclude_paths`, `exclude_domains`, `allow_external`, and `categories`.
+- All other parameters can also be set during invocation: `max_depth`, `max_breadth`, `limit`, `instructions`, `select_paths`, `select_domains`, `exclude_paths`, `exclude_domains`, `allow_external`, `categories`, and `include_usage`.
 
 NOTE: If you set an argument during instantiation this value will persist and overwrite the value passed during invocation.
 
@@ -490,4 +496,8 @@ This example shows how to:
 4. Process a user query that requires both searching and crawling capabilities
 
 The agent will first use the search tool to find Apple's base URL, then use the crawl tool to explore the website and find information about iPhone models.
+
+### Include Usage With OpenAI or Anthropic Agents
+
+When wiring these tools into `langchain_openai.ChatOpenAI` or `langchain_anthropic.ChatAnthropic`, set `include_usage=True` on the tool (or pass `{"include_usage": True}` in the agent call) whenever you want Tavily to return credit usage. The flag is optional, defaults to `False`, and reported usage may stay at `0` until Tavily's usage accounting reaches the necessary thresholds for the request.
 

--- a/langchain_tavily/_utilities.py
+++ b/langchain_tavily/_utilities.py
@@ -53,6 +53,7 @@ class TavilySearchAPIWrapper(BaseModel):
         time_range: Optional[Literal["day", "week", "month", "year"]],
         country: Optional[str],
         auto_parameters: Optional[bool],
+        include_usage: Optional[bool],
         start_date: Optional[str],
         end_date: Optional[str],
         **kwargs: Any,
@@ -72,6 +73,7 @@ class TavilySearchAPIWrapper(BaseModel):
             "time_range": time_range,
             "country": country,
             "auto_parameters": auto_parameters,
+            "include_usage": include_usage,
             "start_date": start_date,
             "end_date": end_date,
             **kwargs,
@@ -116,6 +118,7 @@ class TavilySearchAPIWrapper(BaseModel):
         time_range: Optional[Literal["day", "week", "month", "year"]],
         country: Optional[str],
         auto_parameters: Optional[bool],
+        include_usage: Optional[bool],
         start_date: Optional[str],
         end_date: Optional[str],
         **kwargs: Any,
@@ -139,6 +142,7 @@ class TavilySearchAPIWrapper(BaseModel):
                 "time_range": time_range,
                 "country": country,
                 "auto_parameters": auto_parameters,
+                "include_usage": include_usage,
                 "start_date": start_date,
                 "end_date": end_date,
                 **kwargs,
@@ -196,6 +200,7 @@ class TavilyExtractAPIWrapper(BaseModel):
         include_images: Optional[bool],
         include_favicon: Optional[bool],
         format: Optional[str],
+        include_usage: Optional[bool],
         **kwargs: Any,
     ) -> Dict[str, Any]:
         params = {
@@ -204,6 +209,7 @@ class TavilyExtractAPIWrapper(BaseModel):
             "include_favicon": include_favicon,
             "extract_depth": extract_depth,
             "format": format,
+            "include_usage": include_usage,
             **kwargs,
         }
 
@@ -239,6 +245,7 @@ class TavilyExtractAPIWrapper(BaseModel):
         include_favicon: Optional[bool],
         extract_depth: Optional[Literal["basic", "advanced"]],
         format: Optional[str],
+        include_usage: Optional[bool],
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Get results from the Tavily Extract API asynchronously."""
@@ -251,6 +258,7 @@ class TavilyExtractAPIWrapper(BaseModel):
                 "include_favicon": include_favicon,
                 "extract_depth": extract_depth,
                 "format": format,
+                "include_usage": include_usage,
                 **kwargs,
             }
 
@@ -331,6 +339,7 @@ class TavilyCrawlAPIWrapper(BaseModel):
         extract_depth: Optional[Literal["basic", "advanced"]],
         include_favicon: Optional[bool],
         format: Optional[str],
+        include_usage: Optional[bool],
         **kwargs: Any,
     ) -> Dict[str, Any]:
         params = {
@@ -349,6 +358,7 @@ class TavilyCrawlAPIWrapper(BaseModel):
             "extract_depth": extract_depth,
             "include_favicon": include_favicon,
             "format": format,
+            "include_usage": include_usage,
             **kwargs,
         }
 
@@ -408,6 +418,7 @@ class TavilyCrawlAPIWrapper(BaseModel):
         extract_depth: Optional[Literal["basic", "advanced"]],
         include_favicon: Optional[bool],
         format: Optional[str],
+        include_usage: Optional[bool],
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Get results from the Tavily Crawl API asynchronously."""
@@ -430,6 +441,7 @@ class TavilyCrawlAPIWrapper(BaseModel):
                 "extract_depth": extract_depth,
                 "include_favicon": include_favicon,
                 "format": format,
+                "include_usage": include_usage,
                 **kwargs,
             }
 
@@ -506,6 +518,7 @@ class TavilyMapAPIWrapper(BaseModel):
                 ]
             ]
         ],
+        include_usage: Optional[bool],
         **kwargs: Any,
     ) -> Dict[str, Any]:
         params = {
@@ -520,6 +533,7 @@ class TavilyMapAPIWrapper(BaseModel):
             "exclude_domains": exclude_domains,
             "allow_external": allow_external,
             "categories": categories,
+            "include_usage": include_usage,
             **kwargs,
         }
 
@@ -575,6 +589,7 @@ class TavilyMapAPIWrapper(BaseModel):
                 ]
             ]
         ],
+        include_usage: Optional[bool],
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Get results from the Tavily Map API asynchronously."""
@@ -593,6 +608,7 @@ class TavilyMapAPIWrapper(BaseModel):
                 "exclude_domains": exclude_domains,
                 "allow_external": allow_external,
                 "categories": categories,
+                "include_usage": include_usage,
                 **kwargs,
             }
 

--- a/langchain_tavily/tavily_crawl.py
+++ b/langchain_tavily/tavily_crawl.py
@@ -158,6 +158,14 @@ class TavilyCrawlInput(BaseModel):
         default=False,
         description="Whether to include the favicon URL for each result.",
     )
+    include_usage: Optional[bool] = Field(
+        default=False,
+        description="""Whether to include credit usage information in the response.
+
+        Usage may initially report as 0 until Tavily accrues enough data for
+        the request.
+        """,
+    )
 
 
 def _generate_suggestions(params: Dict[str, Any]) -> List[str]:
@@ -292,6 +300,11 @@ class TavilyCrawl(BaseTool):  # type: ignore[override]
     
     Default is False.
     """
+    include_usage: Optional[bool] = None
+    """Whether to include credit usage information in the response.
+    
+    Default is False.
+    """
 
     api_wrapper: TavilyCrawlAPIWrapper = Field(default_factory=TavilyCrawlAPIWrapper)  # type: ignore[arg-type]
 
@@ -337,6 +350,7 @@ class TavilyCrawl(BaseTool):  # type: ignore[override]
         ] = None,
         extract_depth: Optional[Literal["basic", "advanced"]] = None,
         include_favicon: Optional[bool] = None,
+        include_usage: Optional[bool] = None,
         run_manager: Optional[CallbackManagerForToolRun] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
@@ -383,6 +397,9 @@ class TavilyCrawl(BaseTool):  # type: ignore[override]
                 include_favicon=self.include_favicon
                 if self.include_favicon
                 else include_favicon,
+                include_usage=self.include_usage
+                if self.include_usage is not None
+                else include_usage,
                 format=self.format,
                 **kwargs,
             )
@@ -444,6 +461,7 @@ class TavilyCrawl(BaseTool):  # type: ignore[override]
         ] = None,
         extract_depth: Optional[Literal["basic", "advanced"]] = None,
         include_favicon: Optional[bool] = None,
+        include_usage: Optional[bool] = None,
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
@@ -478,6 +496,9 @@ class TavilyCrawl(BaseTool):  # type: ignore[override]
                 include_favicon=self.include_favicon
                 if self.include_favicon
                 else include_favicon,
+                include_usage=self.include_usage
+                if self.include_usage is not None
+                else include_usage,
                 format=self.format,
                 **kwargs,
             )

--- a/langchain_tavily/tavily_extract.py
+++ b/langchain_tavily/tavily_extract.py
@@ -47,6 +47,13 @@ class TavilyExtractInput(BaseModel):
         default=False,
         description="Whether to include the favicon URL for each result.",
     )
+    include_usage: Optional[bool] = Field(
+        default=False,
+        description="""Whether to include credit usage information in the response.
+
+        Usage may report as 0 until reporting thresholds are met.
+        """,
+    )
 
 
 def _generate_suggestions(params: Dict[str, Any]) -> List[str]:
@@ -103,6 +110,11 @@ class TavilyExtract(BaseTool):  # type: ignore[override, override]
     
     Default is False.
     """
+    include_usage: Optional[bool] = None
+    """Whether to include credit usage information in the response.
+    
+    Default is False.
+    """
     apiwrapper: TavilyExtractAPIWrapper = Field(default_factory=TavilyExtractAPIWrapper)  # type: ignore[arg-type]
 
     def __init__(self, **kwargs: Any) -> None:
@@ -122,6 +134,7 @@ class TavilyExtract(BaseTool):  # type: ignore[override, override]
         extract_depth: Optional[Literal["basic", "advanced"]] = None,
         include_images: Optional[bool] = None,
         include_favicon: Optional[bool] = None,
+        include_usage: Optional[bool] = None,
         run_manager: Optional[CallbackManagerForToolRun] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
@@ -139,6 +152,9 @@ class TavilyExtract(BaseTool):  # type: ignore[override, override]
                 include_favicon=self.include_favicon
                 if self.include_favicon
                 else include_favicon,
+                include_usage=self.include_usage
+                if self.include_usage is not None
+                else include_usage,
                 format=self.format,
                 **kwargs,
             )
@@ -173,6 +189,7 @@ class TavilyExtract(BaseTool):  # type: ignore[override, override]
         extract_depth: Optional[Literal["basic", "advanced"]] = None,
         include_images: Optional[bool] = None,
         include_favicon: Optional[bool] = None,
+        include_usage: Optional[bool] = None,
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
@@ -189,6 +206,9 @@ class TavilyExtract(BaseTool):  # type: ignore[override, override]
                 include_favicon=self.include_favicon
                 if self.include_favicon
                 else include_favicon,
+                include_usage=self.include_usage
+                if self.include_usage is not None
+                else include_usage,
                 format=self.format,
                 **kwargs,
             )

--- a/langchain_tavily/tavily_map.py
+++ b/langchain_tavily/tavily_map.py
@@ -143,6 +143,14 @@ class TavilyMapInput(BaseModel):
         ex. "Crawl tavily.com for API documentation" ---> categories="Documentation"
     """,  # noqa: E501
     )
+    include_usage: Optional[bool] = Field(
+        default=False,
+        description="""Whether to include credit usage information in the response.
+
+        Usage numbers may report as 0 until Tavily accumulates enough data for
+        that request.
+        """,
+    )
 
 
 def _generate_suggestions(params: Dict[str, Any]) -> List[str]:
@@ -252,6 +260,11 @@ class TavilyMap(BaseTool):  # type: ignore[override]
     ] = None
     """Filter URLs using predefined categories like 'Documentation', 'Blogs', etc.
     """
+    include_usage: Optional[bool] = None
+    """Whether to include credit usage information in the response.
+    
+    Default is False.
+    """
     api_wrapper: TavilyMapAPIWrapper = Field(default_factory=TavilyMapAPIWrapper)  # type: ignore[arg-type]
 
     def __init__(self, **kwargs: Any) -> None:
@@ -293,6 +306,7 @@ class TavilyMap(BaseTool):  # type: ignore[override]
                 ]
             ]
         ] = None,
+        include_usage: Optional[bool] = None,
         run_manager: Optional[CallbackManagerForToolRun] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
@@ -331,6 +345,9 @@ class TavilyMap(BaseTool):  # type: ignore[override]
                 if self.allow_external
                 else allow_external,
                 categories=self.categories if self.categories else categories,
+                include_usage=self.include_usage
+                if self.include_usage is not None
+                else include_usage,
                 **kwargs,
             )
 
@@ -387,6 +404,7 @@ class TavilyMap(BaseTool):  # type: ignore[override]
                 ]
             ]
         ] = None,
+        include_usage: Optional[bool] = None,
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
     ) -> Dict[str, Any]:
         """Use the tool asynchronously."""
@@ -411,6 +429,9 @@ class TavilyMap(BaseTool):  # type: ignore[override]
                 if self.allow_external
                 else allow_external,
                 categories=self.categories if self.categories else categories,
+                include_usage=self.include_usage
+                if self.include_usage is not None
+                else include_usage,
             )
 
             # Check if results are empty and raise a specific exception

--- a/langchain_tavily/tavily_search.py
+++ b/langchain_tavily/tavily_search.py
@@ -111,6 +111,14 @@ class TavilySearchInput(BaseModel):
         Default is False to minimize response size and API usage.
         """,  # noqa: E501
     )
+    include_usage: Optional[bool] = Field(
+        default=False,
+        description="""Whether to include credit usage information in the response.
+
+        Leave as False to minimize payload size. When enabled, credit usage may
+        initially report as 0 until the request meets reporting thresholds.
+        """,  # noqa: E501
+    )
     start_date: Optional[str] = Field(
         default=None,
         description="""Filters search results to include only content published on or after this date.
@@ -328,6 +336,11 @@ class TavilySearch(BaseTool):  # type: ignore[override]
     
     Default is False.
     """
+    include_usage: Optional[bool] = None
+    """Whether to include credit usage information in the response.
+    
+    Default is False.
+    """
     api_wrapper: TavilySearchAPIWrapper = Field(default_factory=TavilySearchAPIWrapper)  # type: ignore[arg-type]
 
     def __init__(self, **kwargs: Any) -> None:
@@ -352,6 +365,7 @@ class TavilySearch(BaseTool):  # type: ignore[override]
         time_range: Optional[Literal["day", "week", "month", "year"]] = None,
         topic: Optional[Literal["general", "news", "finance"]] = None,
         include_favicon: Optional[bool] = None,
+        include_usage: Optional[bool] = None,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
         run_manager: Optional[CallbackManagerForToolRun] = None,
@@ -389,6 +403,9 @@ class TavilySearch(BaseTool):  # type: ignore[override]
                 include_favicon=self.include_favicon
                 if self.include_favicon
                 else include_favicon,
+                include_usage=self.include_usage
+                if self.include_usage is not None
+                else include_usage,
                 country=self.country,
                 max_results=self.max_results,
                 include_answer=self.include_answer,
@@ -435,6 +452,7 @@ class TavilySearch(BaseTool):  # type: ignore[override]
         time_range: Optional[Literal["day", "week", "month", "year"]] = None,
         topic: Optional[Literal["general", "news", "finance"]] = "general",
         include_favicon: Optional[bool] = False,
+        include_usage: Optional[bool] = None,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
@@ -459,6 +477,9 @@ class TavilySearch(BaseTool):  # type: ignore[override]
                 include_favicon=self.include_favicon
                 if self.include_favicon
                 else include_favicon,
+                include_usage=self.include_usage
+                if self.include_usage is not None
+                else include_usage,
                 country=self.country,
                 max_results=self.max_results,
                 include_answer=self.include_answer,

--- a/tests/unit_tests/test_tavily_crawl.py
+++ b/tests/unit_tests/test_tavily_crawl.py
@@ -52,3 +52,15 @@ class TestTavilyCrawlToolUnit(ToolsUnitTests):  # Fixed class name to match its 
         have {"name", "id", "args"} keys.
         """
         return {"url": "https://en.wikipedia.org/wiki/Japan"}
+
+    def test_include_usage_forwarded(self) -> None:
+        mock_response = {"results": [{"url": "https://example.com"}]}
+        with patch(
+            "langchain_tavily.tavily_crawl.TavilyCrawlAPIWrapper.raw_results",
+            return_value=mock_response,
+        ) as mock_raw:
+            tool = TavilyCrawl(tavily_api_key="fake_key_for_testing")
+            tool._run(url="https://en.wikipedia.org/wiki/Japan", include_usage=True)
+
+        assert mock_raw.called
+        assert mock_raw.call_args.kwargs["include_usage"] is True

--- a/tests/unit_tests/test_tavily_extract.py
+++ b/tests/unit_tests/test_tavily_extract.py
@@ -42,3 +42,17 @@ class TestTavilyExtractToolUnit(ToolsUnitTests):
         have {"name", "id", "args"} keys.
         """
         return {"urls": ["https://en.wikipedia.org/wiki/Lionel_Messi"]}
+
+    def test_include_usage_forwarded(self) -> None:
+        mock_response = {"results": [{"url": "https://example.com"}], "failed_results": []}
+        with patch(
+            "langchain_tavily.tavily_extract.TavilyExtractAPIWrapper.raw_results",
+            return_value=mock_response,
+        ) as mock_raw:
+            tool = TavilyExtract(tavily_api_key="fake_key_for_testing")
+            tool._run(
+                urls=["https://en.wikipedia.org/wiki/Lionel_Messi"], include_usage=True
+            )
+
+        assert mock_raw.called
+        assert mock_raw.call_args.kwargs["include_usage"] is True

--- a/tests/unit_tests/test_tavily_map.py
+++ b/tests/unit_tests/test_tavily_map.py
@@ -51,3 +51,15 @@ class TestTavilyMapToolUnit(ToolsUnitTests):  # Fixed class name to match its pu
         have {"name", "id", "args"} keys.
         """
         return {"url": "https://en.wikipedia.org/wiki/Japan"}
+
+    def test_include_usage_forwarded(self) -> None:
+        mock_response = {"results": ["https://example.com"]}
+        with patch(
+            "langchain_tavily.tavily_map.TavilyMapAPIWrapper.raw_results",
+            return_value=mock_response,
+        ) as mock_raw:
+            tool = TavilyMap(tavily_api_key="fake_key_for_testing")
+            tool._run(url="https://en.wikipedia.org/wiki/Japan", include_usage=True)
+
+        assert mock_raw.called
+        assert mock_raw.call_args.kwargs["include_usage"] is True

--- a/tests/unit_tests/test_tavily_search.py
+++ b/tests/unit_tests/test_tavily_search.py
@@ -45,3 +45,15 @@ class TestTavilySearchToolUnit(ToolsUnitTests):  # Fixed class name to match its
         have {"name", "id", "args"} keys.
         """
         return {"query": "best time to visit japan"}
+
+    def test_include_usage_forwarded(self) -> None:
+        mock_response = {"results": [{"url": "https://example.com", "content": ""}]}
+        with patch(
+            "langchain_tavily.tavily_search.TavilySearchAPIWrapper.raw_results",
+            return_value=mock_response,
+        ) as mock_raw:
+            tool = TavilySearch(tavily_api_key="fake_key_for_testing")
+            tool._run(query="best time to visit japan", include_usage=True)
+
+        assert mock_raw.called
+        assert mock_raw.call_args.kwargs["include_usage"] is True


### PR DESCRIPTION
Expose the include_usage flag through search, extract, crawl, and map tools, propagate it via the shared wrappers, and cover the SDK/docs/tests so LangChain clients can request credit usage data.