### PR TITLE
feat: add exact_match parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The tool accepts various parameters during instantiation:
 - `include_domains` (optional, List[str]): List of domains to specifically include. Default is None.
 - `exclude_domains` (optional, List[str]): List of domains to specifically exclude. Default is None.
 - `country` (optional, str): Boost search results from a specific country. This will prioritize content from the selected country in the search results. Available only if topic is general.
+- `exact_match` (optional, bool): When True, enables exact string matching for quoted phrases in the query (e.g. `"machine learning" applications in "healthcare"`). Default is False.
 
 For a comprehensive overview of the available parameters, refer to the [Tavily Search API documentation](https://docs.tavily.com/documentation/api-reference/endpoint/search)
 
@@ -72,6 +73,7 @@ tool = TavilySearch(
     # include_domains=None,
     # exclude_domains=None,
     # country=None
+    # exact_match=False,
 )
 ```
 

--- a/langchain_tavily/_utilities.py
+++ b/langchain_tavily/_utilities.py
@@ -57,6 +57,7 @@ class TavilySearchAPIWrapper(BaseModel):
         start_date: Optional[str],
         end_date: Optional[str],
         include_usage: Optional[bool],
+        exact_match: Optional[bool] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         params = {
@@ -77,6 +78,7 @@ class TavilySearchAPIWrapper(BaseModel):
             "start_date": start_date,
             "end_date": end_date,
             "include_usage": include_usage,
+            "exact_match": exact_match,
             **kwargs,
         }
 
@@ -122,6 +124,7 @@ class TavilySearchAPIWrapper(BaseModel):
         start_date: Optional[str],
         end_date: Optional[str],
         include_usage: Optional[bool],
+        exact_match: Optional[bool] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Get results from the Tavily Search API asynchronously."""
@@ -146,6 +149,7 @@ class TavilySearchAPIWrapper(BaseModel):
                 "start_date": start_date,
                 "end_date": end_date,
                 "include_usage": include_usage,
+                "exact_match": exact_match,
                 **kwargs,
             }
 

--- a/langchain_tavily/tavily_search.py
+++ b/langchain_tavily/tavily_search.py
@@ -199,6 +199,7 @@ class TavilySearch(BaseTool):  # type: ignore[override]
             # country=None
             # include_favicon=False
             # include_usage=False
+            # exact_match=False,
         )
         ```
 
@@ -242,15 +243,23 @@ class TavilySearch(BaseTool):  # type: ignore[override]
     auto_parameters: Optional[bool] = None
     """
     When `auto_parameters` is enabled, Tavily automatically configures search parameters
-    based on your query's content and intent. You can still set other parameters 
-    manually, and your explicit values will override the automatic ones. The parameters 
-    `include_answer`, `include_raw_content`, and `max_results` must always be set 
-    manually, as they directly affect response size. Note: `search_depth` may be 
+    based on your query's content and intent. You can still set other parameters
+    manually, and your explicit values will override the automatic ones. The parameters
+    `include_answer`, `include_raw_content`, and `max_results` must always be set
+    manually, as they directly affect response size. Note: `search_depth` may be
     automatically set to advanced when it's likely to improve results. This uses 2 API
-    credits per request. To avoid the extra cost, you can explicitly set `search_depth` 
-    to `basic`. 
+    credits per request. To avoid the extra cost, you can explicitly set `search_depth`
+    to `basic`.
 
     Default is `False`.
+    """
+
+    exact_match: Optional[bool] = None
+    """When True, quoted phrases in the query are preserved for exact string matching
+    instead of being stripped. Use for due diligence, data enrichment, or legal queries
+    where precise phrase matching is required.
+
+    Default is False.
     """
 
     include_domains: Optional[List[str]] = None
@@ -365,15 +374,16 @@ class TavilySearch(BaseTool):  # type: ignore[override]
         """
         try:
             forbidden_params = [
-                "include_usage", "auto_parameters", "max_results", "include_answer", 
-                "include_raw_content", "include_image_descriptions", "include_favicon", "country"
+                "include_usage", "auto_parameters", "max_results", "include_answer",
+                "include_raw_content", "include_image_descriptions", "include_favicon",
+                "country", "exact_match",
             ]
             for param in forbidden_params:
                 if param in kwargs:
                     raise ValueError(
                         f"The parameter '{param}' can only be set during instantiation, not during invocation. Please set it when creating the TavilySearch instance."
                     )
-            
+
             # Execute search with parameters directly
             raw_results = self.api_wrapper.raw_results(
                 query=query,
@@ -399,6 +409,7 @@ class TavilySearch(BaseTool):  # type: ignore[override]
                 start_date=start_date,
                 end_date=end_date,
                 include_usage=self.include_usage,
+                exact_match=self.exact_match,
                 **kwargs,
             )
 
@@ -444,15 +455,16 @@ class TavilySearch(BaseTool):  # type: ignore[override]
         """Use the tool asynchronously."""
         try:
             forbidden_params = [
-                "include_usage", "auto_parameters", "max_results", "include_answer", 
-                "include_raw_content", "include_image_descriptions", "include_favicon", "country"
+                "include_usage", "auto_parameters", "max_results", "include_answer",
+                "include_raw_content", "include_image_descriptions", "include_favicon",
+                "country", "exact_match",
             ]
             for param in forbidden_params:
                 if param in kwargs:
                     raise ValueError(
                         f"The parameter '{param}' can only be set during instantiation, not during invocation. Please set it when creating the TavilySearch instance."
                     )
-            
+
             raw_results = await self.api_wrapper.raw_results_async(
                 query=query,
                 include_domains=self.include_domains
@@ -477,6 +489,7 @@ class TavilySearch(BaseTool):  # type: ignore[override]
                 start_date=start_date,
                 end_date=end_date,
                 include_usage=self.include_usage,
+                exact_match=self.exact_match,
                 **kwargs,
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-tavily"
-version = "0.2.17"
+version = "0.2.18"
 description = "An integration package connecting Tavily and LangChain"
 authors = []
 readme = "README.md"

--- a/tests/unit_tests/test_tavily_search.py
+++ b/tests/unit_tests/test_tavily_search.py
@@ -46,3 +46,98 @@ class TestTavilySearchToolUnit(ToolsUnitTests):  # Fixed class name to match its
         """
         return {"query": "best time to visit japan"}
 
+
+@pytest.fixture(autouse=True)
+def _patch_api_key_validation(request):
+    """Patch API key validation for all tests in this module."""
+    patcher = patch(
+        "langchain_tavily._utilities.TavilySearchAPIWrapper.validate_environment"
+    )
+    patcher.start()
+    request.addfinalizer(patcher.stop)
+
+
+class TestExactMatch:
+    """Tests for exact_match parameter support."""
+
+    def test_exact_match_accepted_at_instantiation(self):
+        """exact_match can be set when creating the tool."""
+        tool = TavilySearch(
+            tavily_api_key="fake_key",
+            exact_match=True,
+        )
+        assert tool.exact_match is True
+
+    def test_exact_match_default_is_none(self):
+        """exact_match defaults to None when not set."""
+        tool = TavilySearch(tavily_api_key="fake_key")
+        assert tool.exact_match is None
+
+    def test_exact_match_not_in_input_schema(self):
+        """exact_match should NOT be in the agent-facing input schema."""
+        schema = TavilySearch.model_fields["args_schema"].default
+        field_names = list(schema.model_fields.keys())
+        assert "exact_match" not in field_names
+
+    def test_exact_match_in_forbidden_params(self):
+        """exact_match is rejected if passed at invocation via kwargs."""
+        tool = TavilySearch(tavily_api_key="fake_key")
+        result = tool._run(query="test", exact_match=True)
+        assert "error" in result
+        assert isinstance(result["error"], ValueError)
+        assert "exact_match" in str(result["error"])
+
+    @patch("langchain_tavily._utilities.requests.post")
+    def test_exact_match_passed_to_api(self, mock_post):
+        """exact_match=True is included in the API request payload."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "query": "test",
+            "results": [{"title": "t", "url": "u", "content": "c", "score": 1}],
+        }
+        mock_post.return_value = mock_response
+
+        tool = TavilySearch(tavily_api_key="fake_key", exact_match=True)
+        tool._run(query='"Sam Altman" CEO')
+
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert payload["exact_match"] is True
+
+    @patch("langchain_tavily._utilities.requests.post")
+    def test_exact_match_none_excluded_from_payload(self, mock_post):
+        """When exact_match is None (default), it's not sent to the API."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "query": "test",
+            "results": [{"title": "t", "url": "u", "content": "c", "score": 1}],
+        }
+        mock_post.return_value = mock_response
+
+        tool = TavilySearch(tavily_api_key="fake_key")
+        tool._run(query="test query")
+
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert "exact_match" not in payload
+
+    @patch("langchain_tavily._utilities.requests.post")
+    def test_exact_match_false_included_in_payload(self, mock_post):
+        """When exact_match=False, it's explicitly sent to the API."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "query": "test",
+            "results": [{"title": "t", "url": "u", "content": "c", "score": 1}],
+        }
+        mock_post.return_value = mock_response
+
+        tool = TavilySearch(tavily_api_key="fake_key", exact_match=False)
+        tool._run(query="test query")
+
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert payload["exact_match"] is False
+


### PR DESCRIPTION
## Summary
- Add `exact_match` as an instantiation-only parameter to `TavilySearch` and the underlying `TavilySearchAPIWrapper`
- When enabled, allows exact string matching for quoted phrases in search queries (e.g. `"machine learning" applications in "healthcare"`)
- Agents cannot toggle this at invocation — enforced via `forbidden_params` in both `_run()` and `_arun()`
- Bump version to 0.2.18

## Test plan
- [x] 13 unit tests pass (6 existing + 7 new for exact_match)
- [ ] Verify exact_match=True sends the param in the API payload
- [ ] Verify exact_match=None (default) omits it from the payload
- [ ] Verify passing exact_match at invocation returns a ValueError

🤖 Generated with [Claude Code](https://claude.com/claude-code)