### PR TITLE
Use raw docstrings for regex examples

### DIFF
--- a/langchain_tavily/tavily_crawl.py
+++ b/langchain_tavily/tavily_crawl.py
@@ -75,7 +75,7 @@ class TavilyCrawlInput(BaseModel):
     )
     select_domains: Optional[List[str]] = Field(
         default=None,
-        description="""Regex patterns to select only URLs from specific domains or subdomains.
+        description=r"""Regex patterns to select only URLs from specific domains or subdomains.
    
         Use when the user explicitly asks for a specific domain or subdomain from a website.
 
@@ -94,7 +94,7 @@ class TavilyCrawlInput(BaseModel):
     )
     exclude_domains: Optional[List[str]] = Field(
         default=None,
-        description="""Regex patterns to exclude URLs from specific domains or subdomains.
+        description=r"""Regex patterns to exclude URLs from specific domains or subdomains.
 
         Use when the user explicitly asks to exclude a specific domain or subdomain from a website.
 
@@ -228,7 +228,7 @@ class TavilyCrawl(BaseTool):  # type: ignore[override]
     ex. ["/api/v1.*"]
     """
     select_domains: Optional[List[str]] = None
-    """Regex patterns to select only URLs from specific domains or subdomains.
+    r"""Regex patterns to select only URLs from specific domains or subdomains.
 
     ex. ["^docs\\.example\\.com$"]
     """
@@ -238,7 +238,7 @@ class TavilyCrawl(BaseTool):  # type: ignore[override]
     ex.  [/private/.*, /admin/.*]
     """
     exclude_domains: Optional[List[str]] = None
-    """
+    r"""
     Regex patterns to exclude specific domains or subdomains from crawling 
     ex. [^private\\.example\\.com$]
     """

--- a/langchain_tavily/tavily_map.py
+++ b/langchain_tavily/tavily_map.py
@@ -75,7 +75,7 @@ class TavilyMapInput(BaseModel):
     )
     select_domains: Optional[List[str]] = Field(
         default=None,
-        description="""Regex patterns to select only URLs from specific domains or subdomains.
+        description=r"""Regex patterns to select only URLs from specific domains or subdomains.
    
         Use when the user explicitly asks for a specific domain or subdomain from a website.
 
@@ -94,7 +94,7 @@ class TavilyMapInput(BaseModel):
     )
     exclude_domains: Optional[List[str]] = Field(
         default=None,
-        description="""Regex patterns to exclude URLs from specific domains or subdomains.
+        description=r"""Regex patterns to exclude URLs from specific domains or subdomains.
 
         Use when the user explicitly asks to exclude a specific domain or subdomain from a website.
 
@@ -216,7 +216,7 @@ class TavilyMap(BaseTool):  # type: ignore[override]
     ex. ["/api/v1.*"]
     """
     select_domains: Optional[List[str]] = None
-    """Regex patterns to select only URLs from specific domains or subdomains.
+    r"""Regex patterns to select only URLs from specific domains or subdomains.
 
     ex. ["^docs\\.example\\.com$"]
     """
@@ -226,7 +226,7 @@ class TavilyMap(BaseTool):  # type: ignore[override]
     ex.  [/private/.*, /admin/.*]
     """
     exclude_domains: Optional[List[str]] = None
-    """
+    r"""
     Regex patterns to exclude specific domains or subdomains from mapping 
     ex. [^private\\.example\\.com$]
     """


### PR DESCRIPTION
Fixes #54.

## Summary
- mark the crawl/map descriptions and docstrings that contain regex examples as raw strings
- preserves the documented regex examples while avoiding Python 3.13+ invalid escape sequence warnings for `\.`

## Validation
- Not run locally
- `git diff --check HEAD~1..HEAD`
- Relying on the remote PR workflow for validation.