### PR TITLE
Raise forbidden TavilySearch invocation params

### DIFF
--- a/langchain_tavily/tavily_search.py
+++ b/langchain_tavily/tavily_search.py
@@ -12,6 +12,30 @@ from pydantic import BaseModel, ConfigDict, Field
 from langchain_tavily._utilities import TavilySearchAPIWrapper
 
 
+_FORBIDDEN_INVOCATION_PARAMS = (
+    "include_usage",
+    "auto_parameters",
+    "max_results",
+    "include_answer",
+    "include_raw_content",
+    "include_image_descriptions",
+    "include_favicon",
+    "country",
+    "exact_match",
+)
+
+
+def _raise_forbidden_invocation_params(kwargs: Dict[str, Any]) -> None:
+    """Raise when a construction-only parameter is passed at invocation time."""
+    for param in _FORBIDDEN_INVOCATION_PARAMS:
+        if param in kwargs:
+            raise ValueError(
+                f"The parameter '{param}' can only be set during instantiation, "
+                "not during invocation. Please set it when creating the "
+                "TavilySearch instance."
+            )
+
+
 class TavilySearchInput(BaseModel):
     """Input for [TavilySearch]"""
 
@@ -368,18 +392,8 @@ class TavilySearch(BaseTool):  # type: ignore[override]
                 - images: List of relevant images (if include_images=True)
                 - response_time: Time taken for the search
         """
+        _raise_forbidden_invocation_params(kwargs)
         try:
-            forbidden_params = [
-                "include_usage", "auto_parameters", "max_results", "include_answer", 
-                "include_raw_content", "include_image_descriptions", "include_favicon", "country",
-                "exact_match"
-            ]
-            for param in forbidden_params:
-                if param in kwargs:
-                    raise ValueError(
-                        f"The parameter '{param}' can only be set during instantiation, not during invocation. Please set it when creating the TavilySearch instance."
-                    )
-            
             # Execute search with parameters directly
             raw_results = self.api_wrapper.raw_results(
                 query=query,
@@ -449,18 +463,8 @@ class TavilySearch(BaseTool):  # type: ignore[override]
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Use the tool asynchronously."""
+        _raise_forbidden_invocation_params(kwargs)
         try:
-            forbidden_params = [
-                "include_usage", "auto_parameters", "max_results", "include_answer", 
-                "include_raw_content", "include_image_descriptions", "include_favicon", "country",
-                "exact_match"
-            ]
-            for param in forbidden_params:
-                if param in kwargs:
-                    raise ValueError(
-                        f"The parameter '{param}' can only be set during instantiation, not during invocation. Please set it when creating the TavilySearch instance."
-                    )
-            
             raw_results = await self.api_wrapper.raw_results_async(
                 query=query,
                 include_domains=self.include_domains

--- a/tests/unit_tests/test_tavily_search.py
+++ b/tests/unit_tests/test_tavily_search.py
@@ -46,3 +46,15 @@ class TestTavilySearchToolUnit(ToolsUnitTests):  # Fixed class name to match its
         """
         return {"query": "best time to visit japan"}
 
+    def test_invoke_raises_for_construction_only_params(self) -> None:
+        tool = TavilySearch(tavily_api_key="fake_key_for_testing", max_results=5)
+
+        with pytest.raises(ValueError, match="max_results"):
+            tool._run("best time to visit japan", max_results=5)
+
+    async def test_ainvoke_raises_for_construction_only_params(self) -> None:
+        tool = TavilySearch(tavily_api_key="fake_key_for_testing", max_results=5)
+
+        with pytest.raises(ValueError, match="max_results"):
+            await tool._arun("best time to visit japan", max_results=5)
+


### PR DESCRIPTION
## Summary
- Move construction-only invocation parameter validation outside the `_run` / `_arun` catch-all blocks.
- Reuse one forbidden-parameter helper for sync and async search paths.
- Add sync and async unit coverage showing `max_results` raises instead of returning an `{error: ...}` payload.

Fixes #74

## Validation
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
- Not run locally beyond static diff checks.