### PR TITLE
fix: raise langchain-core floor to >=1.3.3 (high-severity CVEs)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2658,4 +2658,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "e3a9b43a611404e8dc41337fd0bb475c72e0430a9dce25a5768664d93e9bf38b"
+content-hash = "85c8b97159bd7b43587406467854d1e9687a3c5742958fd831586239b53e6692"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ disallow_untyped_defs = "True"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
-langchain-core = ">=1.2.11,<2.0.0"
+langchain-core = ">=1.3.3,<2.0.0"
 langchain = ">=1.0.0,<2.0.0"
 aiohttp = "^3.11.14"
 requests = "^2.32.3"


### PR DESCRIPTION
## Summary
- Raises the `langchain-core` constraint floor from `>=1.2.11` to `>=1.3.3` to resolve two high-severity advisories for consumers of this published package:
  - Path traversal in legacy `load_prompt` functions (`<1.2.22`)
  - Unsafe deserialization via overly broad `load()` allowlists (`<=1.3.2`)
- The lock already resolves langchain-core **1.4.0**; only the published lower bound and the lock content-hash change.

> Note: this is a published library, so the dependency is expressed as a floor (`>=1.3.3,<2.0.0`) rather than an exact pin to avoid forcing a single langchain-core version on downstream users.

## Test plan
- [ ] `poetry install` resolves
- [ ] LangChain Tavily tools import and invoke correctly